### PR TITLE
feat: update to target noir `>=0.19.2`

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,5 +1,7 @@
 [package]
+name="noir_rln"
+type="bin"
 authors = [""]
-compiler_version = "0.6.0"
+compiler_version = ">=0.19.2"
 
 [dependencies]

--- a/src/main.nr
+++ b/src/main.nr
@@ -14,21 +14,21 @@ struct Output {
 
 fn main(
     identitySecret: Field, 
-    userMessageLimit: Field,
-    messageId: Field,
-    pathSelectors: [Field; DEPTH],
+    userMessageLimit: u16,
+    messageId: u16,
+    pathSelectors: [u1; DEPTH],
     pathElements: [Field; DEPTH],
     x: pub Field, 
     externalNullifier: pub Field
 ) -> pub Output {
     let identityCommitment = hash_1([identitySecret]);
-    let rateCommitment = hash_2([identityCommitment, userMessageLimit]);
+    let rateCommitment = hash_2([identityCommitment, userMessageLimit as Field]);
 
     let root = merkle_proof(rateCommitment, pathSelectors, pathElements);
 
-    assert(messageId as u16 < userMessageLimit as u16);
+    assert(messageId < userMessageLimit, "messageId exceeds limit");
 
-    let a1 = hash_3([identitySecret, externalNullifier, messageId]);
+    let a1 = hash_3([identitySecret, externalNullifier, messageId as Field]);
     let y = identitySecret + a1 * x;
 
     let nullifier = hash_1([a1]);

--- a/src/utils.nr
+++ b/src/utils.nr
@@ -1,31 +1,19 @@
 use dep::std::hash::poseidon::bn254::hash_2;
 
 global DEPTH = 16;
-global HASHES_LENGTH = 17;
 
-fn merkle_proof<N>(leaf: Field, pathSelectors: [Field; N], pathElements: [Field; N]) -> Field {
-    let mut levelHashes = [0; HASHES_LENGTH];
-    levelHashes[0] = leaf;
+pub fn merkle_proof<N>(leaf: Field, pathSelectors: [u1; N], pathElements: [Field; N]) -> Field {
+    let mut hash = leaf;
 
     for i in 0..N {
-        assert(pathSelectors[i] * (pathSelectors[i] - 1) == 0);
+        let hash_input = if pathSelectors[i] == 1 {
+            [pathElements[i], hash]
+        } else {
+            [hash, pathElements[i]]
+        };
 
-        let leaves = mux(
-            [levelHashes[i], pathElements[i], pathElements[i], levelHashes[i]],
-            pathSelectors[i]
-        );
-
-        levelHashes[i + 1] = hash_2([leaves[0], leaves[1]]);
+        hash = hash_2(hash_input);
     }
 
-    levelHashes[N]
-}
-
-fn mux(c: [Field; 4], s: Field) -> [Field; 2] {
-    let mut out: [Field; 2] = [0; 2];
-
-    out[0] = (c[1] - c[0]) * s + c[0];
-    out[1] = (c[3] - c[2]) * s + c[2];
-
-    out
+    hash
 }


### PR DESCRIPTION
This PR updates `noir-rln` to be be compile-able on modern versions of Noir. I've taken the opportunity to make the crate  more idiomatic Noir at the same time:

- Usage of `if-else` syntax rather than `mux` in merkle tree proof
- Usage of unsigned integer types in the function interface